### PR TITLE
Cleaned up links in examples README

### DIFF
--- a/examples/fluorescence-binding-assay/README.md
+++ b/examples/fluorescence-binding-assay/README.md
@@ -4,8 +4,7 @@ More information on experiment to follow.
 
 ## IPython notebooks
 * [Fitting Src-bosutinib fluorescence emission scans](http://nbviewer.ipython.org/github/choderalab/assaytools/blob/master/examples/fluorescence-binding-assay/fitting-fluorescence-scans.ipynb)
-* [Fitting Src-bosutinib titration assay](http://nbviewer.ipython.org/github/choderalab/assaytools/blob/master/examples/fluorescence-binding-assay/fitting-fluorescence-titration-assay.ipynb)
-* [Fitting p38-bosutinib titration assay](http://nbviewer.ipython.org/github/choderalab/assaytools/blob/master/examples/fluorescence-binding-assay/fluorescence-binding-assay/p38%20analysis%20(no%20absorbance).ipynb)
+* [Fitting p38-bosutinib titration assay](http://nbviewer.ipython.org/github/choderalab/assaytools/blob/master/examples/fluorescence-binding-assay/p38%20analysis%20(no%20absorbance).ipynb)
 * [Src-bosutinib isomer](http://nbviewer.ipython.org/github/choderalab/assaytools/blob/master/examples/fluorescence-binding-assay/Src-bosutinib%20isomer%20fluorescence.ipynb).
 * [Src-bosutinib in UV-transparent plate](http://nbviewer.ipython.org/github/choderalab/assaytools/blob/master/examples/fluorescence-binding-assay/Src-bosutinib%20with%20absorbance%20measurements%20in%20Greiner%20UV-Star%20plate.ipynb)
 * [Src-bosutinib in non-UV-transparent plate](http://nbviewer.ipython.org/github/choderalab/assaytools/blob/master/examples/fluorescence-binding-assay/Src-bosutinib%20with%20absorbance%20measurements%20in%20ScreenStar%20plate.ipynb)


### PR DESCRIPTION
I've just cleaned up some of the broken links in the fluorescence examples `README.md`
