### PR TITLE
Updating quickmodel with more options and to use parser function.

### DIFF
--- a/AssayTools/parser.py
+++ b/AssayTools/parser.py
@@ -48,6 +48,13 @@ for j in string.ascii_uppercase:
 # This function requires an inputs dictionary with a single xml file input.
 
 def get_data_using_inputs(inputs):
+
+    """
+    Parameters
+    ----------
+    inputs : dict
+        Dictionary of input information
+    """
     
     data = platereader.read_icontrol_xml(inputs['my_file'])
     
@@ -58,7 +65,7 @@ def get_data_using_inputs(inputs):
         protein_row = ALPHABET[i]
         buffer_row = ALPHABET[i+1]
 
-        name = "%s-%s%s"%(inputs['ligand_order'][i/2],protein_row,buffer_row)
+        name = "%s-%s%s"%(inputs['ligand_order'][int(i/2)],protein_row,buffer_row)
 
         complex_fluorescence_data = platereader.select_data(data, inputs['section'], protein_row)
         ligand_fluorescence_data = platereader.select_data(data, inputs['section'], buffer_row)

--- a/AssayTools/parser.py
+++ b/AssayTools/parser.py
@@ -45,33 +45,65 @@ for j in string.ascii_uppercase:
 # Parsing functions
 #=============================================================================================
 
-# This function requires an inputs dictionary with a single xml file input.
 
 def get_data_using_inputs(inputs):
 
     """
+    Parses your data according to inputs dictionary. Currently requires single xml file input or spectra analysis.
     Parameters
     ----------
     inputs : dict
         Dictionary of input information
     """
-    
-    data = platereader.read_icontrol_xml(inputs['my_file'])
-    
-    complex_fluorescence = {}
-    ligand_fluorescence = {}
-    
-    for i in range(0,15,2):
-        protein_row = ALPHABET[i]
-        buffer_row = ALPHABET[i+1]
 
-        name = "%s-%s%s"%(inputs['ligand_order'][int(i/2)],protein_row,buffer_row)
+    if 'wavelength' in inputs:
+        
+        complex_fluorescence = {}
+        ligand_fluorescence = {}
+        
+        for protein in inputs['file_set'].keys():
 
-        complex_fluorescence_data = platereader.select_data(data, inputs['section'], protein_row)
-        ligand_fluorescence_data = platereader.select_data(data, inputs['section'], buffer_row)
+            #concatenate four spectra xmls into one dictionary with all ligand data
 
-        complex_fluorescence[name] = reorder2list(complex_fluorescence_data,well)
-        ligand_fluorescence[name] = reorder2list(ligand_fluorescence_data,well)
+            my_file = []
+
+            data = platereader.read_icontrol_xml(inputs['file_set']['%s'%protein][0])
+            for file in inputs['file_set']['%s'%protein]:
+                my_file.append(file)
+                new_dict = platereader.read_icontrol_xml(file)
+                for key in data:
+                    data[key] = dict(data[key].items()+new_dict[key].items())
+    
+            for i in range(0,7,2):
+                protein_row = ALPHABET[i]
+                buffer_row = ALPHABET[i+1]
+
+                name = "%s-%s-%s%s"%(protein,inputs['ligand_order'][i/2],protein_row,buffer_row)
+ 
+                complex_fluorescence_data = platereader.select_data(data, inputs['section'], protein_row, wavelength = '%s' %inputs['wavelength'])
+                ligand_fluorescence_data = platereader.select_data(data, inputs['section'], buffer_row, wavelength = '%s' %inputs['wavelength'])
+
+                complex_fluorescence[name] = reorder2list(complex_fluorescence_data,well)
+                ligand_fluorescence[name] = reorder2list(ligand_fluorescence_data,well)
+    
+    else:
+
+        data = platereader.read_icontrol_xml(inputs['my_file'])
+    
+        complex_fluorescence = {}
+        ligand_fluorescence = {}
+    
+        for i in range(0,15,2):
+            protein_row = ALPHABET[i]
+            buffer_row = ALPHABET[i+1]
+
+            name = "%s-%s%s"%(inputs['ligand_order'][int(i/2)],protein_row,buffer_row)
+
+            complex_fluorescence_data = platereader.select_data(data, inputs['section'], protein_row)
+            ligand_fluorescence_data = platereader.select_data(data, inputs['section'], buffer_row)
+
+            complex_fluorescence[name] = reorder2list(complex_fluorescence_data,well)
+            ligand_fluorescence[name] = reorder2list(ligand_fluorescence_data,well)
 
     return [complex_fluorescence, ligand_fluorescence]
  

--- a/AssayTools/parser.py
+++ b/AssayTools/parser.py
@@ -49,61 +49,61 @@ for j in string.ascii_uppercase:
 def get_data_using_inputs(inputs):
 
     """
-    Parses your data according to inputs dictionary. Currently requires single xml file input or spectra analysis.
+    Parses your data according to inputs dictionary. Requires you have a 'file_set' in your inputs.
     Parameters
     ----------
     inputs : dict
         Dictionary of input information
     """
-
-    if 'wavelength' in inputs:
+    complex_fluorescence = {}
+    ligand_fluorescence = {}
         
-        complex_fluorescence = {}
-        ligand_fluorescence = {}
+    for protein in inputs['file_set'].keys():
+
+        #concatenate xmls into one dictionary with all ligand data
+
+        my_file = []
+
+        # Data just helps define our keys, which will be our data sections.
+        # We are importing the first two files, because sometimes we have two files per
+        # data collection, e.g. if we wanted a lot of types of reads 
+        # (there is a limited number of type of read on the infinite per script).
+        data = platereader.read_icontrol_xml(inputs['file_set']['%s'%protein][0])
+        try:
+            data.update(platereader.read_icontrol_xml(inputs['file_set']['%s'%protein][1]))
+        except:
+            pass
         
-        for protein in inputs['file_set'].keys():
-
-            #concatenate four spectra xmls into one dictionary with all ligand data
-
-            my_file = []
-
-            data = platereader.read_icontrol_xml(inputs['file_set']['%s'%protein][0])
-            for file in inputs['file_set']['%s'%protein]:
-                my_file.append(file)
-                new_dict = platereader.read_icontrol_xml(file)
-                for key in data:
+        for file in inputs['file_set']['%s'%protein]:
+            my_file.append(file)
+            new_dict = platereader.read_icontrol_xml(file)
+            for key in data:
+                try:
                     data[key].update(new_dict[key])
+                except:
+                    pass
     
-            for i in range(0,7,2):
-                protein_row = ALPHABET[i]
-                buffer_row = ALPHABET[i+1]
-
-                name = "%s-%s-%s%s"%(protein,inputs['ligand_order'][int(i/2)],protein_row,buffer_row)
- 
-                complex_fluorescence_data = platereader.select_data(data, inputs['section'], protein_row, wavelength = '%s' %inputs['wavelength'])
-                ligand_fluorescence_data = platereader.select_data(data, inputs['section'], buffer_row, wavelength = '%s' %inputs['wavelength'])
-
-                complex_fluorescence[name] = reorder2list(complex_fluorescence_data,well)
-                ligand_fluorescence[name] = reorder2list(ligand_fluorescence_data,well)
-    
-    else:
-
-        data = platereader.read_icontrol_xml(inputs['my_file'])
-    
-        complex_fluorescence = {}
-        ligand_fluorescence = {}
-    
-        for i in range(0,15,2):
+        for i in range(0,7,2):
             protein_row = ALPHABET[i]
             buffer_row = ALPHABET[i+1]
 
-            name = "%s-%s%s"%(inputs['ligand_order'][int(i/2)],protein_row,buffer_row)
+            name = "%s-%s-%s%s"%(protein,inputs['ligand_order'][int(i/2)],protein_row,buffer_row)
+ 
+            # for spectra assays
+            if 'wavelength' in inputs:
+        
+                complex_fluorescence_data = platereader.select_data(data, inputs['section'], protein_row, wavelength = '%s' %inputs['wavelength'])
+                ligand_fluorescence_data = platereader.select_data(data, inputs['section'], buffer_row, wavelength = '%s' %inputs['wavelength'])
 
-            complex_fluorescence_data = platereader.select_data(data, inputs['section'], protein_row)
-            ligand_fluorescence_data = platereader.select_data(data, inputs['section'], buffer_row)
-
+            # for single wavelength assays
+            else:
+                
+                complex_fluorescence_data = platereader.select_data(data, inputs['section'], protein_row)
+                ligand_fluorescence_data = platereader.select_data(data, inputs['section'], buffer_row)
+                
             complex_fluorescence[name] = reorder2list(complex_fluorescence_data,well)
-            ligand_fluorescence[name] = reorder2list(ligand_fluorescence_data,well)
+            ligand_fluorescence[name] = reorder2list(ligand_fluorescence_data,well) 
 
     return [complex_fluorescence, ligand_fluorescence]
+
  

--- a/AssayTools/parser.py
+++ b/AssayTools/parser.py
@@ -72,13 +72,13 @@ def get_data_using_inputs(inputs):
                 my_file.append(file)
                 new_dict = platereader.read_icontrol_xml(file)
                 for key in data:
-                    data[key] = dict(data[key].items()+new_dict[key].items())
+                    data[key].update(new_dict[key])
     
             for i in range(0,7,2):
                 protein_row = ALPHABET[i]
                 buffer_row = ALPHABET[i+1]
 
-                name = "%s-%s-%s%s"%(protein,inputs['ligand_order'][i/2],protein_row,buffer_row)
+                name = "%s-%s-%s%s"%(protein,inputs['ligand_order'][int(i/2)],protein_row,buffer_row)
  
                 complex_fluorescence_data = platereader.select_data(data, inputs['section'], protein_row, wavelength = '%s' %inputs['wavelength'])
                 ligand_fluorescence_data = platereader.select_data(data, inputs['section'], buffer_row, wavelength = '%s' %inputs['wavelength'])

--- a/AssayTools/pymcmodels.py
+++ b/AssayTools/pymcmodels.py
@@ -233,20 +233,20 @@ def inner_filter_effect_attenuation(epsilon_ex, epsilon_em, path_length, concent
 
     scaling = 1.0 # no attenuation
 
+    def compute_scaling(alpha):
+        scaling = np.zeros(alpha.shape, np.float64)
+        small_indices = np.where(np.abs(alpha) < 0.01)
+        large_indices = np.where(np.abs(alpha) >= 0.01)
+        scaling[large_indices] = (1 - np.exp(-alpha[large_indices])) / alpha[large_indices]
+        scaling[small_indices] = 1. - alpha[small_indices]/2. + (alpha[small_indices]**2)/6. - (alpha[small_indices]**3)/24. + (alpha[small_indices]**4)/120.
+        return scaling
+
     if geometry == 'top':
         alpha = (ELC_ex + ELC_em)
-
-        scaling = (1 - np.exp(-alpha)) / alpha
-        # Handle alpha -> 0 case explicitly.
-        indices = np.where(np.abs(alpha) < 0.01)
-        scaling[indices] = 1. - alpha[indices]/2. + (alpha[indices]**2)/6. - (alpha[indices]**3)/24. + (alpha[indices]**4)/120.
+        scaling = compute_scaling(alpha)
     elif geometry == 'bottom':
         alpha = (ELC_ex - ELC_em)
-
-        scaling = (1 - np.exp(-alpha)) / alpha
-        # Handle alpha -> 0 case explicitly.
-        indices = np.where(np.abs(alpha) < 0.01)
-        scaling[indices] = 1. - alpha[indices]/2. + (alpha[indices]**2)/6. - (alpha[indices]**3)/24. + (alpha[indices]**4)/120.
+        scaling = compute_scaling(alpha)
         # Include additional term.
         scaling *= np.exp(-ELC_em)
     else:

--- a/examples/direct-fluorescence-assay/inputs_p38_singlet.py
+++ b/examples/direct-fluorescence-assay/inputs_p38_singlet.py
@@ -1,12 +1,13 @@
 import json
 import numpy as np
+from glob import glob
 
 inputs = {
     'xml_file_path' :  "./data/single_wavelength_copy",
+    'file_set'      :  {'p38' : glob( "./data/single_wavelength_copy/*.xml")},
     'section'       :  '280_480_TOP_120',
     'ligand_order'  :  ['Bosutinib','Bosutinib Isomer','Erlotinib','Gefitinib','Ponatinib','Lapatinib','Saracatinib','Vandetanib'],
     'Lstated'       :  np.array([20.0e-6,14.0e-6,9.82e-6,6.88e-6,4.82e-6,3.38e-6,2.37e-6,1.66e-6,1.16e-6,0.815e-6,0.571e-6,0.4e-6,0.28e-6,0.196e-6,0.138e-6,0.0964e-6,0.0676e-6,0.0474e-6,0.0320e-6,0.0240e-6,0.0160e-6,0.0120e-6,0.008e-6,0.0], np.float64), # ligand concentration, M
-    'protein'       :  'p38',
     'Pstated'       :  0.5e-6 * np.ones([24],np.float64), # protein concentration, M
     'assay_volume'  :  50e-6, # assay volume, L
     'well_area'     :  0.1369, # well area, cm^2 for 4ti-0203 [http://4ti.co.uk/files/3113/4217/2464/4ti-0201.pdf]

--- a/scripts/inputs_example.py
+++ b/scripts/inputs_example.py
@@ -1,11 +1,12 @@
 import json
 import numpy as np
+import os
 
 inputs = {
-    'xml_file_path' :  "/Users/hansons/Documents/github/fluorescence-assay-manuscript/data/singlet/DMSO-backfill/",
+    'xml_file_path' :  "%s/fluorescence-assay-manuscript/data/singlet/DMSO-backfill/"%os.environ['GITHUB_PATH'],
     'section'       :  '280_480_TOP_120',
     'ligand_order'  :  ['Bosutinib','Bosutinib Isomer','Erlotinib','Gefitinib','Bosutinib','Bosutinib Isomer','Erlotinib','Gefitinib'],
-    'Lstated'       :  np.array([20.0e-6,14.0e-6,9.82e-6,6.88e-6,4.82e-6,3.38e-6,2.37e-6,1.66e-6,1.16e-6,0.815e-6,0.571e-6,0.4e-6,0.28e-6,0.196e-6,0.138e-6,0.0964e-6,0.0676e-6,0.0474e-6,0.0320e-6,0.0240e-6,0.0160e-6,0.0120e-6,0.008e-6,0.00001e-6], np.float64), # ligand concentration, M
+    'Lstated'       :  np.array([20.0e-6,14.0e-6,9.82e-6,6.88e-6,4.82e-6,3.38e-6,2.37e-6,1.66e-6,1.16e-6,0.815e-6,0.571e-6,0.4e-6,0.28e-6,0.196e-6,0.138e-6,0.0964e-6,0.0676e-6,0.0474e-6,0.0320e-6,0.0240e-6,0.0160e-6,0.0120e-6,0.008e-6,0.0], np.float64), # ligand concentration, M
     'protein'       :  'p38',
     'Pstated'       :  0.5e-6 * np.ones([24],np.float64), # protein concentration, M
     'assay_volume'  :  50e-6, # assay volume, L

--- a/scripts/inputs_example.py
+++ b/scripts/inputs_example.py
@@ -1,13 +1,14 @@
 import json
 import numpy as np
 import os
+from glob import glob
 
 inputs = {
     'xml_file_path' :  "%s/fluorescence-assay-manuscript/data/singlet/DMSO-backfill/"%os.environ['GITHUB_PATH'],
+    'file_set'      :  {'p38': glob("%s/fluorescence-assay-manuscript/data/singlet/DMSO-backfill/*.xml"%os.environ['GITHUB_PATH'])},
     'section'       :  '280_480_TOP_120',
     'ligand_order'  :  ['Bosutinib','Bosutinib Isomer','Erlotinib','Gefitinib','Bosutinib','Bosutinib Isomer','Erlotinib','Gefitinib'],
     'Lstated'       :  np.array([20.0e-6,14.0e-6,9.82e-6,6.88e-6,4.82e-6,3.38e-6,2.37e-6,1.66e-6,1.16e-6,0.815e-6,0.571e-6,0.4e-6,0.28e-6,0.196e-6,0.138e-6,0.0964e-6,0.0676e-6,0.0474e-6,0.0320e-6,0.0240e-6,0.0160e-6,0.0120e-6,0.008e-6,0.0], np.float64), # ligand concentration, M
-    'protein'       :  'p38',
     'Pstated'       :  0.5e-6 * np.ones([24],np.float64), # protein concentration, M
     'assay_volume'  :  50e-6, # assay volume, L
     'well_area'     :  0.1369, # well area, cm^2 for 4ti-0203 [http://4ti.co.uk/files/3113/4217/2464/4ti-0201.pdf]

--- a/scripts/quickmodel.py
+++ b/scripts/quickmodel.py
@@ -393,6 +393,8 @@ def quick_model_spectra(inputs, nsamples=1000, nthin=20):
             np.save('DeltaG_%s-%s.npy'%(name, my_datetime_filename),DeltaG)
             np.save('DeltaG_trace_%s-%s.npy'%(name, my_datetime_filename),mcmc.DeltaG.trace())
 
+            plt.close('all') # close all figures
+
             Kd = np.exp(mcmc.DeltaG.trace().mean())
             dKd = np.exp(mcmc.DeltaG.trace()).std()
 

--- a/scripts/quickmodel.py
+++ b/scripts/quickmodel.py
@@ -20,7 +20,7 @@ import pymbar
 
 def quick_model(inputs, nsamples=1000, nthin=20):
     """
-    Quick model spectra
+    Quick model for both spectra and single wavelength experiments
 
     Parameters
     ----------

--- a/scripts/quickmodel.py
+++ b/scripts/quickmodel.py
@@ -271,6 +271,7 @@ def quick_model_spectra(inputs, nsamples=1000, nthin=20):
         Thinning interval ; number of MCMC steps per sample collected
     """
 
+
     [complex_fluorescence, ligand_fluorescence] = parser.get_data_using_inputs(inputs)  
 
     for name in complex_fluorescence.keys():
@@ -321,6 +322,8 @@ def quick_model_spectra(inputs, nsamples=1000, nthin=20):
             #from assaytools import plots
             #figure = plots.plot_measurements(Lstated, Pstated, pymc_model, mcmc=mcmc)
             #Code below inspired by import above, but didn't quite work to import it...
+            plt.switch_backend('agg')
+
             plt.clf()
             plt.figure(figsize=(8,8))
 
@@ -431,6 +434,8 @@ def quick_model_spectra(inputs, nsamples=1000, nthin=20):
 
             metadata.update(outputs)
 
+            metadata['bin_edges'] = metadata['bin_edges'].tolist()
+            metadata['hist'] = metadata['hist'].tolist()
             metadata['Pstated'] = metadata['Pstated'].tolist()
             metadata['Lstated'] = metadata['Lstated'].tolist()
 

--- a/scripts/quickmodel.py
+++ b/scripts/quickmodel.py
@@ -286,8 +286,8 @@ def quick_model_spectra(inputs, nsamples=1000, nthin=20):
 
             from assaytools import pymcmodels
             pymc_model = pymcmodels.make_model(inputs['Pstated'], dPstated, inputs['Lstated'], dLstated,
-               top_complex_fluorescence=reorder_protein,
-               top_ligand_fluorescence=reorder_buffer,
+               top_complex_fluorescence=complex_fluorescence[name],
+               top_ligand_fluorescence=ligand_fluorescence[name],
                use_primary_inner_filter_correction=True,
                use_secondary_inner_filter_correction=True,
                assay_volume=inputs['assay_volume'], DG_prior='uniform')
@@ -413,12 +413,20 @@ def quick_model_spectra(inputs, nsamples=1000, nthin=20):
 
             outputs = {
                 #'raw_data_file'   : my_file,
-                'name'            : name,
-                'analysis'        : 'pymcmodels', #right now this is hardcoded, BOOO
-                'outfiles'        : '%s_mcmc-%s.pickle, delG_%s-%s.pdf,DeltaG_%s-%s.npy,DeltaG_trace_%s-%s.npy'%(name,my_datetime,name,my_datetime,name,my_datetime,name,my_datetime),
-                'DeltaG'          : "DeltaG = %.1f +- %.1f kT, MAP estimate = %.1f" % (DeltaG, dDeltaG, DeltaG_map),
-                'Kd'              : Kd_summary,
-                'datetime'        : my_datetime
+                'complex_fluorescence' : complex_fluorescence[name],
+                'ligand_fluorescence'  : ligand_fluorescence[name],
+                't_equil'              : t,
+                'name'                 : name,
+                'analysis'             : 'pymcmodels', #right now this is hardcoded, BOOO
+                'outfiles'             : '%s_mcmc-%s.pickle, delG_%s-%s.pdf,DeltaG_%s-%s.npy,DeltaG_trace_%s-%s.npy'%(name,my_datetime,name,my_datetime,name,my_datetime,name,my_datetime),
+                'DeltaG_cred_int'      : '$\Delta G$ =  %.3g [%.3g,%.3g] $k_B T$'  %(interval[1],interval[0],interval[2]),
+                'DeltaG'               : "DeltaG = %.1f +- %.1f kT, MAP estimate = %.1f" % (DeltaG, dDeltaG, DeltaG_map),
+                'Kd'                   : Kd_summary,
+                'bin_edges'            : bin_edges,
+                'hist'                 : hist,
+                'binwidth'             : binwidth,
+                'clrs'                 : clrs,
+                'datetime'             : my_datetime
             }
 
             metadata.update(outputs)

--- a/scripts/quickmodel.py
+++ b/scripts/quickmodel.py
@@ -179,6 +179,7 @@ def quick_model(inputs, nsamples=1000, nthin=20):
             else:
                 Kd_summary = "%.3e M +- %.3e M" % (Kd, dKd)
 
+
             outputs = {
                 #'raw_data_file'   : my_file,
                 'complex_fluorescence' : complex_fluorescence[name],
@@ -201,6 +202,7 @@ def quick_model(inputs, nsamples=1000, nthin=20):
 
             metadata['ligand_fluorescence'] = metadata['ligand_fluorescence'].tolist()
             metadata['complex_fluorescence'] = metadata['complex_fluorescence'].tolist()
+            metadata['t_equil'] = metadata['t_equil'].tolist()
             metadata['bin_edges'] = metadata['bin_edges'].tolist()
             metadata['hist'] = metadata['hist'].tolist()
             metadata['Pstated'] = metadata['Pstated'].tolist()

--- a/scripts/quickmodel.py
+++ b/scripts/quickmodel.py
@@ -6,13 +6,11 @@
 #        or
 #        python quickmodel.py --inputs 'inputs_spectra_example' --type 'spectra'
 
-from assaytools import platereader
 from assaytools import parser
 import matplotlib.pyplot as plt
 import string
 from glob import glob
 import os
-import string
 import json
 import numpy as np
 import traceback
@@ -20,244 +18,7 @@ import traceback
 import seaborn as sns
 import pymbar
 
-def reorder2list(data,well):
-
-    sorted_keys = sorted(well.keys(), key=lambda k:well[k])
-
-    reorder_data = []
-
-    for key in sorted_keys:
-        try:
-            reorder_data.append(data[key])
-        except:
-            pass
-
-    reorder_data = [r.replace('OVER','70000') for r in reorder_data]
-
-    reorder_data = np.asarray(reorder_data,np.float64)
-
-    return reorder_data
-
-ALPHABET = string.ascii_uppercase
-
-well = dict()
-for j in string.ascii_uppercase:
-    for i in range(1,25):
-        well['%s' %j + '%s' %i] = i
-
 def quick_model(inputs, nsamples=1000, nthin=20):
-    """
-    Quick model single wavelength experiment
-
-    Parameters
-    ----------
-    inputs : dict
-        Dictionary of input information
-    nsamples : int, optional, default=20000
-        Number of MCMC samples to collect
-    nthin : int, optiona, default=20
-        Thinning interval ; number of MCMC steps per sample collected
-    """
-
-    xml_files = glob("%s/*.xml" % inputs['xml_file_path'])
-
-    print(xml_files)
-
-    for my_file in xml_files:
-
-        file_name = os.path.splitext(my_file)[0]
-
-        print(file_name)
-
-        data = platereader.read_icontrol_xml(my_file)
-
-        for i in range(0,15,2):
-            protein_row = ALPHABET[i]
-            buffer_row = ALPHABET[i+1]
-
-            name = "%s-%s%s"%(inputs['ligand_order'][int(i/2)],protein_row,buffer_row)
-
-            print(name)
-
-            metadata = {}
-            metadata = dict(inputs)
-
-            try:
-                part1_data_protein = platereader.select_data(data, inputs['section'], protein_row)
-                part1_data_buffer = platereader.select_data(data, inputs['section'], buffer_row)
-            except Exception as e:
-                # Print exception
-                print("An exception occurred while processing '%s' rows %s and %s:" % (my_file, protein_row, buffer_row))
-                print(traceback.print_exc())
-                continue
-
-            reorder_protein = reorder2list(part1_data_protein,well)
-            reorder_buffer = reorder2list(part1_data_buffer,well)
-
-            #these need to be changed so they are TAKEN FROM INPUTS!!!
-
-            # Uncertainties in protein and ligand concentrations.
-            dPstated = 0.35 * inputs['Pstated'] # protein concentration uncertainty
-            dLstated = 0.08 * inputs['Lstated'] # ligand concentraiton uncertainty (due to gravimetric preparation and HP D300 dispensing)
-
-            from assaytools import pymcmodels
-            pymc_model = pymcmodels.make_model(inputs['Pstated'], dPstated, inputs['Lstated'], dLstated,
-               top_complex_fluorescence=reorder_protein,
-               top_ligand_fluorescence=reorder_buffer,
-               use_primary_inner_filter_correction=True,
-               use_secondary_inner_filter_correction=True,
-               assay_volume=inputs['assay_volume'], DG_prior='uniform')
-
-            import datetime
-            my_datetime = datetime.datetime.now().strftime("%Y-%m-%d %H:%M")
-            my_datetime_filename = datetime.datetime.now().strftime("%Y-%m-%d %H%M")
-
-            nburn = 0 # no longer need burn-in since we do automated equilibration detection
-            niter = nthin*nsamples # former total simulation time
-            mcmc = pymcmodels.run_mcmc(pymc_model,
-                nthin=nthin, nburn=nburn, niter=niter,
-                db = 'pickle', dbname = '%s_mcmc-%s.pickle'%(name,my_datetime))
-
-            map = pymcmodels.map_fit(pymc_model)
-
-            pymcmodels.show_summary(pymc_model, map, mcmc)
-
-            DeltaG_map = map.DeltaG.value
-            DeltaG = mcmc.DeltaG.trace().mean()
-            dDeltaG = mcmc.DeltaG.trace().std()
-
-            ## DEFINE EQUILIBRATION
-            #Calculate a mean and std from DeltaG trace after equil
-
-            [t,g,Neff_max] = pymbar.timeseries.detectEquilibration(mcmc.DeltaG.trace())
-            DeltaG_equil = mcmc.DeltaG.trace()[t:].mean()
-            dDeltaG_equil = mcmc.DeltaG.trace()[t:].std()
-
-            ## PLOT MODEL
-            #from assaytools import plots
-            #figure = plots.plot_measurements(Lstated, Pstated, pymc_model, mcmc=mcmc)
-            #Code below inspired by import above, but didn't quite work to import it...
-            plt.clf()
-            plt.figure(figsize=(8,8))
-
-            plt.subplot(311)
-            property_name = 'top_complex_fluorescence'
-            complex = getattr(pymc_model, property_name)
-            #plt.semilogx(inputs['Lstated'], complex.value, 'ko',label='complex')
-            property_name = 'top_ligand_fluorescence'
-            ligand = getattr(pymc_model, property_name)
-            #plt.semilogx(inputs['Lstated'], ligand.value, 'ro',label='ligand')
-            for top_complex_fluorescence_model in mcmc.top_complex_fluorescence_model.trace()[:t:10]:
-                plt.semilogx(inputs['Lstated'], top_complex_fluorescence_model, marker='',color='silver', alpha=0.8)
-            for top_complex_fluorescence_model in mcmc.top_complex_fluorescence_model.trace()[t::10]:
-                plt.semilogx(inputs['Lstated'], top_complex_fluorescence_model, marker='',color='silver', alpha=0.2)
-            for top_ligand_fluorescence_model in mcmc.top_ligand_fluorescence_model.trace()[:t:10]:
-                plt.semilogx(inputs['Lstated'], top_ligand_fluorescence_model, marker='',color='lightcoral', alpha=0.8)
-            for top_ligand_fluorescence_model in mcmc.top_ligand_fluorescence_model.trace()[t::10]:
-                plt.semilogx(inputs['Lstated'], top_ligand_fluorescence_model, marker='',color='lightcoral', alpha=0.2)
-            plt.semilogx(inputs['Lstated'], complex.value, 'ko',label='complex')
-            plt.semilogx(inputs['Lstated'], ligand.value, marker='o',color='firebrick',linestyle='None',label='ligand')
-
-            plt.xlabel('$[L]_T$ (M)');
-            plt.ylabel('fluorescence units');
-            plt.legend(loc=0);
-
-            ## PLOT HISTOGRAM
-            import matplotlib.patches as mpatches
-            import matplotlib.lines as mlines
-
-            interval = np.percentile(a=mcmc.DeltaG.trace()[t:], q=[2.5, 50.0, 97.5])
-            [hist,bin_edges] = np.histogram(mcmc.DeltaG.trace()[t:],bins=40,normed=True)
-            binwidth = np.abs(bin_edges[0]-bin_edges[1])
-
-            #set colors for 95% interval
-            clrs = [(0.7372549019607844, 0.5098039215686274, 0.7411764705882353) for xx in bin_edges]
-            idxs = bin_edges.argsort()
-            idxs = idxs[::-1]
-            gray_before = idxs[bin_edges[idxs] < interval[0]]
-            gray_after = idxs[bin_edges[idxs] > interval[2]]
-            for idx in gray_before:
-                clrs[idx] = (.5,.5,.5)
-            for idx in gray_after:
-                clrs[idx] = (.5,.5,.5)
-
-            plt.subplot(312)
-
-            plt.bar(bin_edges[:-1],hist,binwidth,color=clrs, edgecolor = "white");
-            sns.kdeplot(mcmc.DeltaG.trace()[t:],bw=.4,color=(0.39215686274509803, 0.7098039215686275, 0.803921568627451),shade=False)
-            plt.axvline(x=interval[0],color=(0.5,0.5,0.5),linestyle='--')
-            plt.axvline(x=interval[1],color=(0.5,0.5,0.5),linestyle='--')
-            plt.axvline(x=interval[2],color=(0.5,0.5,0.5),linestyle='--')
-            plt.axvline(x=DeltaG_map,color='black')
-            plt.xlabel('$\Delta G$ ($k_B T$)',fontsize=16);
-            plt.ylabel('$P(\Delta G)$',fontsize=16);
-            plt.xlim(-35,-10)
-            hist_legend = mpatches.Patch(color=(0.7372549019607844, 0.5098039215686274, 0.7411764705882353),
-                        label = '$\Delta G$ =  %.3g [%.3g,%.3g] $k_B T$'
-                        %(interval[1],interval[0],interval[2]) )
-            map_legend = mlines.Line2D([],[],color='black',label="MAP = %.1f $k_B T$"%DeltaG_map)
-            plt.legend(handles=[hist_legend,map_legend],fontsize=14,loc=0,frameon=True);
-
-            #plt.hist(mcmc.DeltaG.trace()[t:], 40, alpha=0.75, label="DeltaG = %.1f +- %.1f kT"%(DeltaG_equil, dDeltaG_equil))
-            #plt.axvline(x=DeltaG,color='blue')
-            #plt.axvline(x=DeltaG_map,color='black',linestyle='dashed',label="MAP = %.1f"%DeltaG_map)
-            #plt.legend(loc=0)
-            #plt.xlabel('$\Delta G$ ($k_B T$)');
-            #plt.ylabel('$P(\Delta G)$');
-            #plt.xlim(-35,-10)
-
-            ## PLOT TRACE
-            plt.subplot(313)
-            plt.plot(range(0,t),mcmc.DeltaG.trace()[:t], 'go',label='equil. at %s'%t);
-            plt.plot(range(t,len(mcmc.DeltaG.trace())),mcmc.DeltaG.trace()[t:], 'o');
-            plt.xlabel('MCMC sample');
-            plt.ylabel('$\Delta G$ ($k_B T$)');
-            plt.legend(loc=2);
-
-            plt.suptitle("%s: %s" % (name, my_datetime))
-            plt.tight_layout()
-
-            fig1 = plt.gcf()
-            fig1.savefig('delG_%s-%s.png'%(name, my_datetime_filename))
-
-            np.save('DeltaG_%s-%s.npy'%(name, my_datetime_filename),DeltaG)
-            np.save('DeltaG_trace_%s-%s.npy'%(name, my_datetime_filename),mcmc.DeltaG.trace())
-
-            Kd = np.exp(mcmc.DeltaG.trace().mean())
-            dKd = np.exp(mcmc.DeltaG.trace()).std()
-
-            if (Kd < 1e-12):
-                Kd_summary = "%.1f nM +- %.1f fM" % (Kd/1e-15, dKd/1e-15)
-            elif (Kd < 1e-9):
-                Kd_summary = "%.1f pM +- %.1f pM" % (Kd/1e-12, dKd/1e-12)
-            elif (Kd < 1e-6):
-                Kd_summary = "%.1f nM +- %.1f nM" % (Kd/1e-9, dKd/1e-9)
-            elif (Kd < 1e-3):
-                Kd_summary = "%.1f uM +- %.1f uM" % (Kd/1e-6, dKd/1e-6)
-            elif (Kd < 1):
-                Kd_summary = "%.1f mM +- %.1f mM" % (Kd/1e-3, dKd/1e-3)
-            else:
-                Kd_summary = "%.3e M +- %.3e M" % (Kd, dKd)
-
-            outputs = {
-                'raw_data_file'   : my_file,
-                'name'            : name,
-                'analysis'        : 'pymcmodels', #right now this is hardcoded, BOOO
-                'outfiles'        : '%s_mcmc-%s.pickle, delG_%s-%s.png,DeltaG_%s-%s.npy,DeltaG_trace_%s-%s.npy'%(name,my_datetime,name,my_datetime,name,my_datetime,name,my_datetime),
-                'DeltaG'          : "DeltaG = %.1f +- %.1f kT, MAP estimate = %.1f" % (DeltaG, dDeltaG, DeltaG_map),
-                'Kd'              : Kd_summary,
-                'datetime'        : my_datetime
-            }
-
-            metadata.update(outputs)
-
-            metadata['Pstated'] = metadata['Pstated'].tolist()
-            metadata['Lstated'] = metadata['Lstated'].tolist()
-
-            with open('%s-%s.json'%(name,my_datetime), 'w') as outfile:
-                json.dump(metadata, outfile, sort_keys = True, indent = 4, ensure_ascii=False)
-
-def quick_model_spectra(inputs, nsamples=1000, nthin=20):
     """
     Quick model spectra
 
@@ -275,6 +36,8 @@ def quick_model_spectra(inputs, nsamples=1000, nthin=20):
     [complex_fluorescence, ligand_fluorescence] = parser.get_data_using_inputs(inputs)  
 
     for name in complex_fluorescence.keys():
+
+            print(name)
 
             metadata = {}
             metadata = dict(inputs)
@@ -318,11 +81,13 @@ def quick_model_spectra(inputs, nsamples=1000, nthin=20):
             DeltaG_equil = mcmc.DeltaG.trace()[t:].mean()
             dDeltaG_equil = mcmc.DeltaG.trace()[t:].std()
 
+            #This is so plotting works on the cluster
+            plt.switch_backend('agg')
+
             ## PLOT MODEL
             #from assaytools import plots
             #figure = plots.plot_measurements(Lstated, Pstated, pymc_model, mcmc=mcmc)
             #Code below inspired by import above, but didn't quite work to import it...
-            plt.switch_backend('agg')
 
             plt.clf()
             plt.figure(figsize=(8,8))
@@ -434,6 +199,8 @@ def quick_model_spectra(inputs, nsamples=1000, nthin=20):
 
             metadata.update(outputs)
 
+            metadata['ligand_fluorescence'] = metadata['ligand_fluorescence'].tolist()
+            metadata['complex_fluorescence'] = metadata['complex_fluorescence'].tolist()
             metadata['bin_edges'] = metadata['bin_edges'].tolist()
             metadata['hist'] = metadata['hist'].tolist()
             metadata['Pstated'] = metadata['Pstated'].tolist()
@@ -473,7 +240,7 @@ def entry_point():
     if args.type == 'singlet':
         quick_model(inputs, nsamples=args.nsamples, nthin=args.nthin)
     if args.type == 'spectra':
-        quick_model_spectra(inputs, nsamples=args.nsamples, nthin=args.nthin)
+        quick_model(inputs, nsamples=args.nsamples, nthin=args.nthin)
 
 if __name__ == '__main__':
     entry_point()

--- a/scripts/trace_plots.py
+++ b/scripts/trace_plots.py
@@ -1,0 +1,53 @@
+import matplotlib
+matplotlib.use('Agg')
+
+# NOTE right now this does not work for py3 because pickle files 
+
+import cPickle
+import matplotlib.pyplot as plt
+import numpy as np
+
+data_file = 'p38-Erlotinib-EF_mcmc-2017-05-05 13:16.pickle'
+###ABOVE INPUT PICKLE FILE NAME NEEDS MANUAL EDITTING
+
+with open(r'%s'%data_file,'rb') as my_file:
+    data = cPickle.load(my_file)
+
+import traceback
+import matplotlib
+colors = matplotlib.cm.viridis(np.linspace(0, 0.85, len(data.keys())))
+
+fig, axs = plt.subplots(len(data.keys())/2,2, figsize=(20, 80), facecolor='w', edgecolor='k')
+axs = axs.ravel()
+
+for i, key in enumerate(data.keys()):
+    try:
+        axs[i].plot(data['DeltaG'][0],data[key][0],color=colors[i],marker='.',linestyle = 'None');
+        axs[i].set_title('%s'%key,fontsize=16);
+        plt.tight_layout()
+    except Exception as e:
+        # There is often an error here for _state_, which it can't plot.
+        # It is fine, just uncomment the line below if you want to see it.
+        #print(traceback.print_exc())
+        print('%s has no [0]'%key)
+
+    plt.savefig('trace_p38-Erlotinib-EF_May5.png')
+    ###ABOVE OUTPUT PNG NAME NEEDS MANUAL EDITTING
+
+plt.clf()
+fig, axs = plt.subplots(len(data.keys())/2,2, figsize=(20, 80), facecolor='w', edgecolor='k')
+axs = axs.ravel()
+for i, key in enumerate(data.keys()):
+    try:
+        axs[i].plot(data[key][0],color=colors[i],marker='.',linestyle = 'None');
+        axs[i].set_title('%s'%key,fontsize=16);
+        plt.tight_layout()
+    except Exception as e:
+        # There is often an error here for _state_, which it can't plot.
+        # It is fine, just uncomment the line below if you want to see it.
+        #print(traceback.print_exc())
+        print('%s has no [0]'%key)
+
+    plt.savefig('DeltaGvall_p38-Erlotinib-EF_May5.png')
+    ###ABOVE OUTPUT PNG NAME NEEDS MANUAL EDITTING
+


### PR DESCRIPTION
Updating quickmodel with a few more options and so that it now uses `parser.py`, which I've been working on for Greg and Mehtap to be usable outside of quickmodel.

Options to add:
 - [ ] Methap's plate format.
 - [ ] Trace png's
 - [ ] Plot two datasets to compare (a la ['constph-grant'](https://github.com/choderalab/constph-grant/blob/master/experimental/ddr1-ponatinib/DDR1-Pon-DelG-figs.ipynb) or 'GK v. WT' requests)
