### PR TITLE
small update to xml2png plotting singlet assay

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,9 @@ script:
   # Test the package
   - cd devtools && nosetests $PACKAGENAME --nocapture --verbosity=2 --with-timer -a '!slow' && cd ..
   # Run quickmodel
-  - pushd . && cd examples/direct-fluorescence-assay && env PYTHONPATH="./" quickmodel --inputs 'inputs_p38_singlet' --nsamples 20 && popd
+  - pushd . && cd examples/direct-fluorescence-assay && quickmodel --inputs 'inputs_p38_singlet' --nsamples 20 && popd
+  # Run xml2png
+  - pushd . && cd examples/direct-fluorescence-assay/data && xml2png --type singlet_384 p38*.xml && popd
   # Run IPython notebook tests
   # THIS NEEDS TO BE REPLACED WITH A PY3.x COMPATIBLE SCHEME
   #- source devtools/travis-ci/ipythontests.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,9 @@ before_script:
   - sleep 3 # give xvfb some time to start
 
 script:
-  # Add org channel
-  - conda config --add channels ${ORGNAME} --add channels conda-forge
+  # Add org channel and force update
+  - conda config --add channels omnia --add channels conda-forge
+  - conda update --yes conda
   # Create a test environment
   - conda create --yes -n test python=$python
   # Activate the test environment

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,7 @@ script:
 
 env:
   - MPLBACKEND="Agg"
+
   matrix:
     - python=2.7  CONDA_PY=27
     - python=3.5  CONDA_PY=35

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,7 @@ script:
   #- source devtools/travis-ci/ipythontests.sh
 
 env:
+  - MPLBACKEND="Agg"
   matrix:
     - python=2.7  CONDA_PY=27
     - python=3.5  CONDA_PY=35

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,14 +44,13 @@ script:
   #- source devtools/travis-ci/ipythontests.sh
 
 env:
-  - MPLBACKEND="Agg"
-
   matrix:
     - python=2.7  CONDA_PY=27
     - python=3.5  CONDA_PY=35
     - python=3.6  CONDA_PY=36
 
   global:
+    - MPLBACKEND="Agg"
     - ORGNAME="omnia"
     - PACKAGENAME="assaytools"
     # encrypted BINSTAR_TOKEN for push of dev package to Anaconda cloud

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -16,7 +16,7 @@ requirements:
     - numpy
     - pandas
     - scipy
-    - openblas
+    - openblas ==0.2.19
     - pymc
     - matplotlib
     - seaborn
@@ -35,7 +35,7 @@ requirements:
     - pint
     - pandas
     - scipy
-    - openblas
+    - openblas ==0.2.19
     - pymc
     - matplotlib
     - seaborn

--- a/scripts/xml2png.py
+++ b/scripts/xml2png.py
@@ -401,20 +401,33 @@ def plot_singlet_one_section(data, section):
         for i in range(1,25):
             well['%s' %j + '%s' %i] = i
 
-    Lstated = np.array([20.0e-6,14.0e-6,9.82e-6,6.88e-6,4.82e-6,3.38e-6,2.37e-6,1.66e-6,1.16e-6,0.815e-6,0.571e-6,0.4e-6,0.28e-6,0.196e-6,0.138e-6,0.0964e-6,0.0676e-6,0.0474e-6,0.0320e-6,0.0240e-6,0.0160e-6,0.0120e-6,0.008e-6,0.00001e-6], np.float64) # ligand concentration, M
-
     for i in range(0,15,2):
         protein_row = ALPHABET[i]
         buffer_row = ALPHABET[i+1]
 
-        part1_data_protein = platereader.select_data(data, section, protein_row)
-        part1_data_buffer = platereader.select_data(data, section, buffer_row)
+        try:
+            part1_data_protein = platereader.select_data(data, section, protein_row)
+            part1_data_buffer = platereader.select_data(data, section, buffer_row)
 
-        reorder_protein = reorder2list(part1_data_protein,well)
-        reorder_buffer = reorder2list(part1_data_buffer,well)
+            reorder_protein = reorder2list(part1_data_protein,well)
+            reorder_buffer = reorder2list(part1_data_buffer,well)
+            
+        except:
+            print '***no %s%s data***' %(protein_row,buffer_row )
+            continue    
+        
+        axes[i/2].set_color_cycle(['black','red'])
 
-        axes[i/2].semilogx()
-        axes[i/2].plot(Lstated,reorder_protein,Lstated,reorder_buffer)
+        if i/2 == 1:
+            axes[i/2].plot(reorder_protein,marker='o',linestyle='None',label='protein+ligand')
+            axes[i/2].plot(reorder_buffer,marker='o',linestyle='None',label='buffer+ligand')
+            axes[i/2].legend(frameon=True)
+
+        axes[i/2].plot(reorder_protein,marker='o',linestyle='None')
+        axes[i/2].plot(reorder_buffer,marker='o',linestyle='None')
+        axes[i/2].set_xticklabels(range(-4,25,5))
+        axes[i/2].set_xlabel('Column Index', horizontalalignment='right',position=(1,1),fontsize=8)
+        axes[i/2].set_ylabel('Fluorescence')
         axes[i/2].set_title('%s,%s' %(protein_row,buffer_row))
 
     fig.suptitle('%s' %section)

--- a/scripts/xml2png.py
+++ b/scripts/xml2png.py
@@ -413,7 +413,7 @@ def plot_singlet_one_section(data, section):
             reorder_buffer = reorder2list(part1_data_buffer,well)
             
         except:
-            print '***no %s%s data***' %(protein_row,buffer_row )
+            print('***no %s%s data***' %(protein_row,buffer_row) )
             continue    
         
         axes[i/2].set_color_cycle(['black','red'])

--- a/scripts/xml2png.py
+++ b/scripts/xml2png.py
@@ -416,19 +416,19 @@ def plot_singlet_one_section(data, section):
             print('***no %s%s data***' %(protein_row,buffer_row) )
             continue    
         
-        axes[i/2].set_color_cycle(['black','red'])
+        axes[int(i/2)].set_color_cycle(['black','red'])
 
         if i/2 == 1:
-            axes[i/2].plot(reorder_protein,marker='o',linestyle='None',label='protein+ligand')
-            axes[i/2].plot(reorder_buffer,marker='o',linestyle='None',label='buffer+ligand')
-            axes[i/2].legend(frameon=True)
+            axes[int(i/2)].plot(reorder_protein,marker='o',linestyle='None',label='protein+ligand')
+            axes[int(i/2)].plot(reorder_buffer,marker='o',linestyle='None',label='buffer+ligand')
+            axes[int(i/2)].legend(frameon=True)
 
-        axes[i/2].plot(reorder_protein,marker='o',linestyle='None')
-        axes[i/2].plot(reorder_buffer,marker='o',linestyle='None')
-        axes[i/2].set_xticklabels(range(-4,25,5))
-        axes[i/2].set_xlabel('Column Index', horizontalalignment='right',position=(1,1),fontsize=8)
-        axes[i/2].set_ylabel('Fluorescence')
-        axes[i/2].set_title('%s,%s' %(protein_row,buffer_row))
+        axes[int(i/2)].plot(reorder_protein,marker='o',linestyle='None')
+        axes[int(i/2)].plot(reorder_buffer,marker='o',linestyle='None')
+        axes[int(i/2)].set_xticklabels(range(-4,25,5))
+        axes[int(i/2)].set_xlabel('Column Index', horizontalalignment='right',position=(1,1),fontsize=8)
+        axes[int(i/2)].set_ylabel('Fluorescence')
+        axes[int(i/2)].set_title('%s,%s' %(protein_row,buffer_row))
 
     fig.suptitle('%s' %section)
 


### PR DESCRIPTION
Small update to xml2png plotting for single wavelength assay.

@MehtapIsik mentioned that the Lstated was hardcoded into this plotting script in xml2png, so now this is plotted by 'column index'. Also changed the plotting to dots and matched the coloring scheme to other plots made by `assaytools`.

This is good to merge on my end, but it'd be great if someone else could check in case I've used an older version of matplotlib that doesn't work for others. @MehtapIsik, @bas-rustenburg, and @jchodera should all have this power (run `xml2png --type singlet_384 *.xml` on any single wavelength 384-well dataset we've collected).