### PR TITLE
Quickmodel modification and adding documentation.

### DIFF
--- a/AssayTools/parser.py
+++ b/AssayTools/parser.py
@@ -86,7 +86,7 @@ def get_data_using_inputs(inputs):
         # Are there any experiments the user wants to skip analyzing?
         skipped_experiments=[]
         for i, ligand in enumerate(inputs['ligand_order']):
-            if ligand == 'skip':
+            if ligand == None:
                 skipped_experiments.append(i*2)
             else:
                 continue

--- a/AssayTools/parser.py
+++ b/AssayTools/parser.py
@@ -82,27 +82,45 @@ def get_data_using_inputs(inputs):
                     data[key].update(new_dict[key])
                 except:
                     pass
-    
-        for i in range(0,len(inputs['ligand_order']*2),2):
-            protein_row = ALPHABET[i]
-            buffer_row = ALPHABET[i+1]
 
-            name = "%s-%s-%s%s"%(protein,inputs['ligand_order'][int(i/2)],protein_row,buffer_row)
- 
-            # for spectra assays
-            if 'wavelength' in inputs:
-        
-                complex_fluorescence_data = platereader.select_data(data, inputs['section'], protein_row, wavelength = '%s' %inputs['wavelength'])
-                ligand_fluorescence_data = platereader.select_data(data, inputs['section'], buffer_row, wavelength = '%s' %inputs['wavelength'])
-
-            # for single wavelength assays
+        # Are there any experiments the user wants to skip analyzing?
+        skipped_experiments=[]
+        for i, ligand in enumerate(inputs['ligand_order']):
+            if ligand == 'skip':
+                skipped_experiments.append(i*2)
             else:
+                continue
+
+        skipped_rows=[]
+        for i in skipped_experiments:
+            skipped_rows.append(ALPHABET[i])
+            skipped_rows.append(ALPHABET[i+1])
+        print("Skipping analysis of rows: ", skipped_rows)
+
+        for i in range(0,len(inputs['ligand_order']*2),2):
+
+            if i in skipped_experiments:
+                continue
+            else:
+                protein_row = ALPHABET[i]
+                buffer_row = ALPHABET[i+1]
+
+                name = "%s-%s-%s%s"%(protein,inputs['ligand_order'][int(i/2)],protein_row,buffer_row)
+ 
+                # for spectra assays
+                if 'wavelength' in inputs:
+        
+                    complex_fluorescence_data = platereader.select_data(data, inputs['section'], protein_row, wavelength = '%s' %inputs['wavelength'])
+                    ligand_fluorescence_data = platereader.select_data(data, inputs['section'], buffer_row, wavelength = '%s' %inputs['wavelength'])
+
+                # for single wavelength assays
+                else:
                 
-                complex_fluorescence_data = platereader.select_data(data, inputs['section'], protein_row)
-                ligand_fluorescence_data = platereader.select_data(data, inputs['section'], buffer_row)
+                    complex_fluorescence_data = platereader.select_data(data, inputs['section'], protein_row)
+                    ligand_fluorescence_data = platereader.select_data(data, inputs['section'], buffer_row)
                 
-            complex_fluorescence[name] = reorder2list(complex_fluorescence_data,well)
-            ligand_fluorescence[name] = reorder2list(ligand_fluorescence_data,well) 
+                complex_fluorescence[name] = reorder2list(complex_fluorescence_data,well)
+                ligand_fluorescence[name] = reorder2list(ligand_fluorescence_data,well)
 
     return [complex_fluorescence, ligand_fluorescence]
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -42,6 +42,7 @@ Documentation
 
    getting_started
    theory
+   useful_scripts
 
 API Reference
 -------------

--- a/docs/useful_scripts.rst
+++ b/docs/useful_scripts.rst
@@ -40,7 +40,12 @@ Ligand concentration array (`Lstated` section) can be constructed using `calcula
 
 - `xml_file_path` : relative path to xml plate reader output files.
 - `file_set` : option to group multiple experimental sets with a dictionary key.
-- `ligand_order`: List of ligand names per each experiment set (one protein, one buffer row). If `skip` is specified as ligand name in this list, `quickmodel` analysis will skip the analysis of that experiment.
+- `ligand_order` : List of ligand names per each experiment set (one protein, one buffer row). If `None` Python object is specified as ligand name in this list, `quickmodel` analysis will skip the analysis of that experiment. For example:
+::
+
+    'ligand_order'  :  [None, None, 'ligand3', 'ligand4']
+
+
 - `section` : Data section label of Tecan Infinite M1000 Pro plate reader as specified in its method.
 - `wavelength` : Emission wavelength picked for analysis (nm).
 - `Lstated` : Experimental value of ligand concentration (M), in NumPy array form. It can be constructed using `calculate_L_stated_array.py` script.

--- a/docs/useful_scripts.rst
+++ b/docs/useful_scripts.rst
@@ -4,30 +4,30 @@ Useful Scripts
 
 .. highlight:: bash
 
-xml2png.py
-==========
+xml2png
+=======
 
 Converts xml data file output from the Tecan Infinite M1000 Pro plate reader to png plot of fluorescence and absorbance values. It allows for the quick visual inspection of raw experimental results.
 
 ::
 
-    $ python python xml2png.py *.xml
+    $ xml2png *.xml --singlet 'singlet_96'
 
 
-quickmodel.py
-=============
+quickmodel
+==========
 
 Builds quick Bayesian model of both spectra and single wavelength two component binding experiments.
 
 As input, it requires xml output files of the experiment form plate reader and a python script(`inputs.py`) that includes all experimental design details.
 
-1. Run `calculate_L_stated_array.py` to generate ligand concentration array and copy it into `inputs.py`.
+1. Run `calculate_L_stated_array` to generate ligand concentration array and copy it into `inputs.py`.
 2. Construct `inputs.py` script based on experimental design.
-3. Run`quickmodel.py`.
+3. Run`quickmodel`.
 
 ::
 
-    $ python quickmodel.py --inputs 'inputs' --type 'singlet' --nsamples 10000
+    $ quickmodel --inputs 'inputs' --type 'singlet' --nsamples 10000
 
 
 inputs.py
@@ -64,7 +64,7 @@ Provide information on how ligand titration is constructed: number of wells in e
 
 ::
 
-    $ python calculate_Lstated_array.py --n_wells 12 --h_conc 8e-06 --l_conc 2.53e-09 --dilution logarithmic
+    $ calculate_Lstated_array --n_wells 12 --h_conc 8e-06 --l_conc 2.53e-09 --dilution logarithmic
 
 The numpy array this script prints out must be directly copied to `Lstated` section of `inputs.py`.
 

--- a/docs/useful_scripts.rst
+++ b/docs/useful_scripts.rst
@@ -1,0 +1,68 @@
+**************
+Useful Scripts
+**************
+
+.. highlight:: bash
+
+xml2png.py
+==========
+
+Converts xml data file output from the Tecan Infinite M1000 Pro plate reader to png plot of fluorescence and absorbance values. It allows for the quick visual inspection of raw experimental results.
+
+::
+
+    $ python python xml2png.py *.xml
+
+
+quickmodel.py
+=============
+
+Builds quick Bayesian model of both spectra and single wavelength two component binding experiments.
+
+As input, it requires xml output files of the experiment form plate reader and a python script(`inputs.py`) that includes all experimental design details.
+
+1. Run `calculate_L_stated_array.py` to generate ligand concentration array and copy it into `inputs.py`.
+2. Construct `inputs.py` script based on experimental design.
+3. Run`quickmodel.py`.
+
+::
+
+    $ python quickmodel.py --inputs 'inputs' --type 'singlet' --nsamples 10000
+
+
+inputs.py
+---------
+
+`inputs.py` should be manually constructed to record experimental design details, following the layout of of `inputs_example.py` file.
+Ligand concentration array (`Lstated` section) can be constructed using `calculate_L_stated_array.py` script.
+
+**Sections of `inputs.py`**
+
+- `xml_file_path` : relative path to xml plate reader output files.
+- `file_set` : option to group multiple experimental sets with a dictionary key.
+- `ligand_order`: List of ligand names per each experiment set (one protein, one buffer row). If `skip` is specified as ligand name in this list, `quickmodel` analysis will skip the analysis of that experiment.
+- `section` : Data section label of Tecan Infinite M1000 Pro plate reader as specified in its method.
+- `wavelength` : Emission wavelength picked for analysis (nm).
+- `Lstated` : Experimental value of ligand concentration (M), in NumPy array form. It can be constructed using `calculate_L_stated_array.py` script.
+- `L_error` : Estimated % error in stated ligand concentrations.
+- `Pstated` : Experimental value of protein concentration (M).
+- `P_error` : Estimated % error in stated protein concentration.
+- `assay_volume` : Volume of each assay sample (L).
+- `well_area` : Area of microtiter plate well (cm^2)
+
+
+calculate_L_stated_array.py
+---------------------------
+
+Generates Numpy array of stated ligand concentration (Lstated) for logarithmic or linear dilution along a row. This numpy array is necessary to construct `inputs.py` file for `quickmodel.py` analysis.
+Provide information on how ligand titration is constructed: number of wells in each titration (`--n_wells`), highest and lowest ligand concentrations in molar units (--h_conc and --l_conc), and serial dilution mode (`--dilution`, linear or logarithmic) as inputs.
+
+::
+
+    $ python calculate_Lstated_array.py --n_wells 12 --h_conc 8e-06 --l_conc 2.53e-09 --dilution logarithmic
+
+The numpy array this script prints out must be directly copied to `Lstated` section of `inputs.py`.
+
+
+
+

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,8 @@ if 'setuptools' in sys.modules:
     setup_kwargs['entry_points'] = {'console_scripts':
               ['xml2png = assaytools.scripts.xml2png:entry_point',
                'quickmodel = assaytools.scripts.quickmodel:entry_point',
-               'ipnbdoctest = assaytools.scripts.ipnbdoctest:entry_point']}
+               'ipnbdoctest = assaytools.scripts.ipnbdoctest:entry_point',
+               'calculate_Lstated_array = assaytools.scripts.calculate_Lstated_array:entry_point']}
 
     if sys.version_info[0] == 2:
         # required to fix cythoninze() for old versions of setuptools on
@@ -42,7 +43,7 @@ if 'setuptools' in sys.modules:
         m = sys.modules['setuptools.extension']
         m.Extension.__dict__ = m._Extension.__dict__
 else:
-    setup_kwargs['scripts'] = ['scripts/xml2png.py','scripts/quickmodel.py']
+    setup_kwargs['scripts'] = ['scripts/xml2png.py','scripts/quickmodel.py','scripts/calculate_Lstated_array.py']
 
 
 ##########################


### PR DESCRIPTION
I modified `parser.py` so that it is possible to skip experiments and analyze part of the plate with `quickmodel`. To skip an experiment (a pair of protein and buffer rows), ligand name must be recorded as `skip` in `ligand_order` section of `inputs.py`.

For example:
`'ligand_order'  :  ['skip', 'skip', 'Dansylglycine', 'Dansylglycine']` will only analyze rows E, F, G and H.

This skipping option became necessary when I used two different excitation wavelengths, thus two different fluorescence measurement sections for two halves of the plate.

I also added `Useful Scripts` page to Assaytools documentation. I recorded this new option there. I also described how the following scripts should be used in coordination to analyze an experiment:
- `inputs.py`
- `calculate_L_stated_array.py`
- `quickmodel.py`
