### PR TITLE
Modified quickmodel to create a csv file of DeltaG and Kd estimates.

### DIFF
--- a/scripts/quickmodel.py
+++ b/scripts/quickmodel.py
@@ -241,30 +241,32 @@ def quick_model(inputs, nsamples=1000, nthin=20):
             # Append Delta G and K_d estimates to summary list, for writing out a summary table.
             protein_name = name.split("-")[0]
             ligand_name = name.split("-")[1]
-            DeltaG_mean = interval[1]
+            DeltaG_median = interval[1]
             DeltaG_lower_CI = interval[0] # 95% Credibility intervals
             DeltaG_upper_CI = interval[2]
+            DeltaG_mean = DeltaG_equil
             DeltaG_STD = dDeltaG_equil
-            Kd_mean = Kd_interval[1]
+            Kd_median = Kd_interval[1]
             Kd_lower_CI = Kd_interval[0]
             Kd_upper_CI = Kd_interval[2]
+            Kd_mean = Kd
             Kd_STD = dKd
-            deltaG_output_summary_list.append((protein_name, ligand_name, "DeltaG", DeltaG_mean, DeltaG_lower_CI,
-                                        DeltaG_upper_CI, DeltaG_STD, "k_BT"))
-            Kd_output_summary_list.append((protein_name, ligand_name, "K_d", Kd_mean, Kd_lower_CI, Kd_upper_CI,
-                                        Kd_STD, "M"))
+            deltaG_output_summary_list.append((protein_name, ligand_name, "DeltaG", DeltaG_median, DeltaG_lower_CI,
+                                        DeltaG_upper_CI, DeltaG_mean, DeltaG_STD, "k_BT"))
+            Kd_output_summary_list.append((protein_name, ligand_name, "K_d", Kd_median, Kd_lower_CI, Kd_upper_CI,
+                                        Kd_mean, Kd_STD, "M"))
 
     # Save DeltaG and K_d estimates of all analyzed experiments in a summary csv file.
     summary_file_name = "%s-delG-and-Kd-summary-%s.csv" % (protein_name, my_datetime_filename)
     writer = open(summary_file_name, "w")
     # Write column names
-    writer.write("%s,%s,%s,%s,%s,%s,%s,%s\n"%("Protein", "Ligand", "Parameter", "Mean", "Lower 95% CrI",
-                                              "Upper 95% CrI", "STD", "Unit"))
+    writer.write("%s,%s,%s,%s,%s,%s,%s,%s,%s\n"%("Protein", "Ligand", "Parameter", "Median", "Lower 95% CrI",
+                                              "Upper 95% CrI", "Mean", "STD", "Unit"))
     # Write values
     for summary_tuple in deltaG_output_summary_list:
-        writer.write("%s,%s,%s,%.3g,%.3g,%.3g,%.3g,%s\n" %summary_tuple)
+        writer.write("%s,%s,%s,%.3g,%.3g,%.3g,%.3g,%.3g,%s\n" %summary_tuple)
     for summary_tuple in Kd_output_summary_list:
-        writer.write("%s,%s,%s,%.3g,%.3g,%.3g,%.3g,%s\n" %summary_tuple)
+        writer.write("%s,%s,%s,%.3g,%.3g,%.3g,%.3g,%.3g,%s\n" %summary_tuple)
 
 
 def entry_point():

--- a/scripts/quickmodel.py
+++ b/scripts/quickmodel.py
@@ -33,8 +33,11 @@ def quick_model(inputs, nsamples=1000, nthin=20):
         Thinning interval ; number of MCMC steps per sample collected
     """
 
+    [complex_fluorescence, ligand_fluorescence] = parser.get_data_using_inputs(inputs)
 
-    [complex_fluorescence, ligand_fluorescence] = parser.get_data_using_inputs(inputs)  
+    # List to store DeltaG and Kd estimates for generating summary csv table.
+    deltaG_output_summary_list = []
+    Kd_output_summary_list = []
 
     for name in complex_fluorescence.keys():
 
@@ -65,8 +68,8 @@ def quick_model(inputs, nsamples=1000, nthin=20):
                assay_volume=inputs['assay_volume'], DG_prior='uniform')
 
             import datetime
-            my_datetime = datetime.datetime.now().strftime("%Y-%m-%d %H:%M")
-            my_datetime_filename = datetime.datetime.now().strftime("%Y-%m-%d %H%M")
+            my_datetime = datetime.datetime.now().strftime("%Y-%m-%d_%H:%M")
+            my_datetime_filename = datetime.datetime.now().strftime("%Y-%m-%d_%H%M")
 
             nburn = 0 # no longer need burn-in since we do automated equilibration detection
             niter = nthin*nsamples # former total simulation time
@@ -232,8 +235,37 @@ def quick_model(inputs, nsamples=1000, nthin=20):
             metadata['Lstated'] = metadata['Lstated'].tolist()
 
             import json
-            with open('%s-%s.json'%(name,my_datetime), 'w') as outfile:
+            with open('%s-%s.json'%(name,my_datetime_filename), 'w') as outfile:
                 json.dump(metadata, outfile, sort_keys = True, indent = 4, ensure_ascii=False)
+
+            # Append Delta G and K_d estimates to summary list, for writing out a summary table.
+            protein_name = name.split("-")[0]
+            ligand_name = name.split("-")[1]
+            DeltaG_mean = interval[1]
+            DeltaG_lower_CI = interval[0] # 95% Credibility intervals
+            DeltaG_upper_CI = interval[2]
+            DeltaG_STD = dDeltaG_equil
+            Kd_mean = Kd_interval[1]
+            Kd_lower_CI = Kd_interval[0]
+            Kd_upper_CI = Kd_interval[2]
+            Kd_STD = dKd
+            deltaG_output_summary_list.append((protein_name, ligand_name, "DeltaG", DeltaG_mean, DeltaG_lower_CI,
+                                        DeltaG_upper_CI, DeltaG_STD, "k_BT"))
+            Kd_output_summary_list.append((protein_name, ligand_name, "K_d", Kd_mean, Kd_lower_CI, Kd_upper_CI,
+                                        Kd_STD, "M"))
+
+    # Save DeltaG and K_d estimates of all analyzed experiments in a summary csv file.
+    summary_file_name = "%s-delG-and-Kd-summary-%s.csv" % (protein_name, my_datetime_filename)
+    writer = open(summary_file_name, "w")
+    # Write column names
+    writer.write("%s,%s,%s,%s,%s,%s,%s,%s\n"%("Protein", "Ligand", "Parameter", "Mean", "Lower 95% CrI",
+                                              "Upper 95% CrI", "STD", "Unit"))
+    # Write values
+    for summary_tuple in deltaG_output_summary_list:
+        writer.write("%s,%s,%s,%.3g,%.3g,%.3g,%.3g,%s\n" %summary_tuple)
+    for summary_tuple in Kd_output_summary_list:
+        writer.write("%s,%s,%s,%.3g,%.3g,%.3g,%.3g,%s\n" %summary_tuple)
+
 
 def entry_point():
 


### PR DESCRIPTION
With increasing number of ligands or experiments, it was getting difficult to extract DeltaG values and confidence intervals from Quickmodel output files. Especially when we wish to compare estimates between different experiments and different runs of quickmodel analysis. For example, diffusion experiment results with 8 ligands and 4 time points.

To eliminate the burden of organizing these values in tables manually, I added a csv table output to `quickmodel.py`, which has DeltaG and K_d estimates and uncertainties for all the experiments in a plate.

<img width="556" alt="screen shot 2017-07-14 at 2 08 31 pm" src="https://user-images.githubusercontent.com/8997658/28225286-23df3882-68a0-11e7-9b07-9e46690833db.png">

I also made a minor change to json output file names to eliminate space and ":" from the file names.
